### PR TITLE
Load theme modules with single method and update layout paths

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,23 +1,10 @@
 /**
  * @file Eleventy’s configuration file
- * @author Reuben L. Lillie <rlilie@pghnaz.org>
+ * @author Reuben L. Lillie <rlillie@pghnaz.org>
  */
 
-// Require local modules
-var arrayFromObject = require('./src/includes/filters/array-from-object')
-var callToAction = require('./src/includes/shortcodes/call-to-action')
-var editThisPage = require('./src/includes/shortcodes/edit-this-page')
-var fileToString = require('./src/includes/filters/file-to-string')
-var favicon = require('./src/includes/shortcodes/favicon')
-var googleMapsAPI = require('./src/includes/shortcodes/google-maps-api')
-var headTag = require('./src/includes/shortcodes/head-tag')
-var minifyCSS = require('./src/includes/filters/minify-css')
-var minifyHTML = require('./src/includes/filters/minify-html')
-var minifyJS = require('./src/includes/filters/minify-js')
-var siteTagline = require('./src/includes/shortcodes/site-tagline')
-var socialLinks = require('./src/includes/shortcodes/social-links')
-var socialMeta = require('./src/includes/shortcodes/social-meta')
-var titleTag = require('./src/includes/shortcodes/title-tag')
+// Require theme modules
+var caimhoff = require('./src/includes/caimhoff')
 
 /**
  * Expose the configuration to 11ty as a function
@@ -27,22 +14,8 @@ var titleTag = require('./src/includes/shortcodes/title-tag')
  */
 module.exports = function (eleventyConfig) {
 
-
-	// Pass 11ty config argument to local modules
-	arrayFromObject(eleventyConfig)
-	callToAction(eleventyConfig)
-	editThisPage(eleventyConfig)
-	fileToString(eleventyConfig)
-	favicon(eleventyConfig)
-	googleMapsAPI(eleventyConfig)
-	headTag(eleventyConfig)
-	minifyCSS(eleventyConfig)
-	minifyHTML(eleventyConfig)
-	minifyJS(eleventyConfig)
-	siteTagline(eleventyConfig)
-	socialLinks(eleventyConfig)
-	socialMeta(eleventyConfig)
-	titleTag(eleventyConfig)
+	// Pass 11ty config argument to theme modules
+	caimhoff(eleventyConfig)
 
 	/**
 	 * Copy static assets directly from includes to output
@@ -60,6 +33,7 @@ module.exports = function (eleventyConfig) {
 			data: 'data', // relative to input
 			includes: 'includes', // relative to input
 			input: 'src',
+			layouts: 'layouts', // relative to input
 			output: 'dist'
 		}
 	}

--- a/src/content/content.11tydata.js
+++ b/src/content/content.11tydata.js
@@ -1,7 +1,7 @@
 module.exports = function () {
 	return {
 		date: 'Last Modified',
-		layout: 'layouts/content',
+		layout: '../includes/layouts/content', // relative to src/layouts/
 		permalink: '/{{page.fileSlug}}/index.html'
 	}
 }

--- a/src/content/pages/church-directory.md
+++ b/src/content/pages/church-directory.md
@@ -1,8 +1,0 @@
----
-title: Church Directory
-layout: layouts/church-directory
----
-
-Check out our interactive [District Map](/map/).
-
-_listed alphabetically by local church name_

--- a/src/content/pages/churches/churches.11tydata.js
+++ b/src/content/pages/churches/churches.11tydata.js
@@ -1,5 +1,5 @@
 module.exports = function () {
 	return {
-		layout: 'layouts/local-church'
+		layout: 'local-church' // relative to src/layouts/
 	}
 }

--- a/src/content/pages/directory.md
+++ b/src/content/pages/directory.md
@@ -1,6 +1,6 @@
 ---
 title: Church Directory
-layout: layouts/church-directory
+layout: church-directory
 ---
 
 Check out our interactive [District Map](/map/).

--- a/src/content/pages/map.md
+++ b/src/content/pages/map.md
@@ -1,6 +1,6 @@
 ---
 title: District Map
-layout: layouts/district-map
+layout: district-map
 ---
 
 Select a marker to interact with the map.

--- a/src/index.md
+++ b/src/index.md
@@ -1,6 +1,6 @@
 ---
 title: Lorem Ipsum
-layout: layouts/content
+layout: ../includes/layouts/content
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/src/layouts/church-directory.11ty.js
+++ b/src/layouts/church-directory.11ty.js
@@ -1,0 +1,71 @@
+/**
+ * @file Defines the nested “Church Directory” template
+ * @author Reuben L. Lillie <rlillie@pghnaz.org>
+ */
+
+/**
+ * An Eleventy JavaScript template using classes and optional data method
+ * @class
+ * @see {@link https://www.11ty.io/docs/languages/javascript/#classes 11ty docs}
+ */
+class ChurchDirectory {
+	data() {
+		return {
+			layout: '../includes/layouts/content' // relative to src/layouts/
+		}
+	}
+
+	render(data) {
+		var arr = Object.keys(data.churches)
+						.map(item => data.churches[item])
+		return `
+			${data.content}
+			<section class="grid">
+				${arr.map(item => {
+					var id = item.properties.gmcID.substr(4)
+					var href = `/${Object.keys(data.churches).find(key => data.churches[key] === item)}`
+					return `
+					<article class="border border-radius more-padding margin shadow" id="church_${id}">
+						<header>
+							<h1>
+								<a href="${href}">
+									<span id="churchName_${id}">
+										${item.properties.name}
+									</span>
+								</a>
+							</h1>
+						</header>
+						<section>
+							<address>
+								${item.properties.address
+									? `
+										<p>
+											<span>${item.properties.address.street}</span></br>
+											<span id="churchCity_${id}">${item.properties.address.city}</span>,
+											<span>${item.properties.address.state}</span>
+											<span>${item.properties.address.zip}</span>
+
+										</p>
+									`
+									: ''
+								}
+							</address>
+							<p>
+								${item.properties.pastor
+									? `Pastor ${item.properties.pastor}`
+									: 'Praying for our next pastor'
+								}
+							</p>
+						</section>
+						<footer class="small">
+							<p><a href="${href}">${data.site.baseURL}${href.substr(1)}</a></p>
+						</footer>
+					</article>
+				`
+			}).join('')}
+			</section>
+		`
+	}
+}
+
+module.exports = ChurchDirectory

--- a/src/layouts/district-map.11ty.js
+++ b/src/layouts/district-map.11ty.js
@@ -1,0 +1,128 @@
+/**
+ * @file Defines the nested “District Map” template
+ * @author Reuben L. Lillie <rlillie@pghnaz.org>
+ */
+
+/**
+ * An Eleventy JavaScript template using classes and optional data method
+ * @class
+ * @see {@link https://www.11ty.io/docs/languages/javascript/#classes 11ty docs}
+ */
+class DistrictMap {
+	data() {
+		return {
+			layout: '../includes/layouts/content' // relative to src/layouts/
+		}
+	}
+
+	render(data) {
+		// Create an array from a JavaScript object containing keyed objects
+		var arr =  this.arrayFromObject(data.churches)
+
+		// The map template
+		return `
+			${data.content}
+			<div id="map"></div>
+			<script async defer>
+			${this.minifyJS(
+				`var map
+				var initMap = function () {
+
+					// Define the map properties
+					var map = new google.maps.Map(document.getElementById('map'), {
+						// Coordinates for Mt. Chestnut Nazarene Center
+						center: {
+							lat: 40.89822,
+							lng: -79.98357
+						},
+						zoom: 7 // wide area, large metropolitan area
+					})
+
+					// An array of GeoJSON feature objects
+					var items = ${JSON.stringify(arr)}
+
+					// Add a map marker with an info window when clicked
+					var addMarker = function (item) {
+
+						var image = {
+							url: '/includes/assets/images/nazarene-logo-map-marker-red.png',
+							size: new google.maps.Size((35.184), 48),
+							origin: new google.maps.Point (0, 0),
+							anchor: new google.maps.Point (0, 48)
+						}
+
+						//Define the map marker properties
+						var marker = new google.maps.Marker({
+							position: {
+								lat: item.geometry.coordinates[1],
+								lng: item.geometry.coordinates[0]
+							},
+							map: map,
+							icon: image
+						})
+
+						// A helper function to format a string like a url
+						var slugify = function (text) {
+							return text.toString().toLowerCase().trim()
+								.replace(/\\s+/g, '-')
+								.replace(/\\-\\-+/g, '-')
+						}
+
+						// A template to load into a Google Maps info window
+						var infoWindowContent = function () {
+							var html = ''
+							var regex = /\s/g
+							item.properties.name
+								? html += '<h2>' +
+									'<a href="/' +
+										slugify(item.properties.name) +
+									'">' +
+									item.properties.name + '<br>Church of the Nazarene' +
+									'</a>' +
+								'</h2>'
+								: html += ''
+							item.properties.pastor
+								? html += '<p>Pastor ' + item.properties.pastor + '</p>'
+								: html += '<p>Praying for our next pastor ' + '</p>'
+							item.properties.address
+								? html += '<address>' +
+									item.properties.address.street + '<br>' +
+									item.properties.address.city + ', ' +
+									item.properties.address.state +  ' ' +
+									item.properties.address.zip +
+								'</address>'
+								: ''
+							item.geometry.coordinates
+								? html += '<p class="small gray">' +
+									item.geometry.coordinates[1] + ', ' +
+									item.geometry.coordinates[0] +
+								'</p>'
+								: ''
+							return html
+						}
+
+						// Define the info window properties
+						var infoWindow = new google.maps.InfoWindow({
+							content: infoWindowContent()
+						})
+
+						// Load an info window when a marker is clicked
+						marker.addListener('click', function () {
+							infoWindow.open(map, marker)
+						})
+
+					}
+
+					// Add a dynamic marker to the map for each item
+					items.forEach(function (item) {
+						addMarker(item)
+					})
+				}`)
+			}
+			</script>
+			${this.googleMapsAPI()}
+		`
+	}
+}
+
+module.exports = DistrictMap

--- a/src/layouts/local-church.11ty.js
+++ b/src/layouts/local-church.11ty.js
@@ -1,0 +1,142 @@
+/**
+ * @file Defines the nested local church template
+ * @author Reuben L. Lillie <rlillie@pghnaz.org>
+ */
+
+/**
+ * An Eleventy JavaScript template using classes and optional data method
+ * @class
+ * @see {@link https://www.11ty.io/docs/languages/javascript/#classes 11ty docs}
+ */
+class LocalChurch {
+	data() {
+		return {
+			layout: '../includes/layouts/content' // relative to src/layouts/
+		}
+	}
+
+	render(data) {
+		var item = data.churches[data.page.fileSlug]
+		var id = item.properties.gmcID.substr(4)
+		return `
+			<article id="article_${id}">
+				<header>
+					<h1>${item.properties.name} Church of the Nazarene</h1>
+				</header>
+				<section>
+					<p class="small gray">
+						${item.properties.gmcID
+							? `ID: <span id="churchID_${id}">
+								${item.properties.gmcID}
+							</span>`
+							: ''
+						}</span>
+						${item.properties.yearOrganized
+							? `Organized: <span id="churchYearOrganized_${id}">
+								${item.properties.yearOrganized}
+							</span>`
+							: ''
+						}
+					</p>
+						${item.properties.address
+							? `<section class="grid grid-repeat-columns">
+									<address>
+									${item.properties.mailingAddress
+										? `<h1>Physical Address</h1>`
+										: ''
+									}
+									<p>
+										<span>${item.properties.address.street}</span></br>
+										<span id="churchCity_${id}">${item.properties.address.city}</span>,
+										<span>${item.properties.address.state}</span>
+										<span>${item.properties.address.zip}</span>
+
+									</p>
+									${item.properties.phone
+										? `<p>
+											<a href="tel:+1${item.properties.phone
+													.toString()
+													.trim()
+													.replace(/[^0-9]/g, '')}">
+												${item.properties.phone}
+											</a>
+										</p>`
+										: ''
+									}
+								</address>
+								${item.properties.mailingAddress
+									? `<address>
+										<h1>Mailing Address</h1>
+										<p>
+											<span>${item.properties.mailingAddress.street}</span></br>
+											<span id="churchCity_${id}">${item.properties.mailingAddress.city}</span>,
+											<span>${item.properties.mailingAddress.state}</span>
+											<span>${item.properties.mailingAddress.zip}</span>
+
+										</p>
+									</address>`
+									: ''
+								}
+							</section>`
+							: ''
+						}
+					<p>
+						${item.properties.pastor
+							? `Pastor ${item.properties.pastor}`
+							: 'Praying for our next pastor'
+						}
+					</p>
+					${item.properties.website
+						? `<p>
+							<a href="${item.properties.website}">
+								${item.properties.website}
+							</a>
+						</p>`
+						: ''
+					}
+					${item.properties.social
+						? `${this.socialLinks(item.properties.social)}`
+						: ''
+					}
+					<div id="map"></div>
+					<p>Find more local churches on our <a href="/map/">District Map</a>.</p>
+				</section>
+				${data.content}
+			</article>
+			<script async defer>
+			${this.minifyJS(`
+				var map
+				var initMap = function () {
+				var map = new google.maps.Map(document.getElementById('map'), {
+					center: {
+						lat: ${item.geometry.coordinates[1]},
+						lng: ${item.geometry.coordinates[0]}
+					},
+					zoom: 13,
+				})
+
+					var image = {
+						url: '/includes/assets/images/nazarene-logo-map-marker-red.png',
+						size: new google.maps.Size((35.184), 48),
+						origin: new google.maps.Point (0, 0),
+						anchor: new google.maps.Point (0, 48)
+					}
+
+					var marker = new google.maps.Marker({
+						position: {
+							lat: ${item.geometry.coordinates[1]},
+							lng: ${item.geometry.coordinates[0]}
+						},
+						map: map,
+						icon: image
+					})
+				}`)
+
+			}
+			</script>
+			${this.googleMapsAPI()}
+		`
+	}
+}
+
+module.exports = LocalChurch


### PR DESCRIPTION
Makes layout files paths in front matter and template/directory data files relative to new `src/layouts/` directory instead of the includes directory. This allows for custom layouts specific to pghnaz.org (e.g., a custom home page) instead of only having layouts in the theme directory. 